### PR TITLE
feat(argocd): add argocd applicationset template.

### DIFF
--- a/argocd/clusters/infrastructure/applicationset.yaml
+++ b/argocd/clusters/infrastructure/applicationset.yaml
@@ -1,0 +1,33 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: cluster-addons
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+  - git:
+      repoURL: https://github.com/zhweiliu/infrastructure
+      revision: main
+      directories:
+      - path: argocd/clusters/infrastructure/*
+  template:
+    metadata:
+      name: 'infrastructure-{{.path.basename}}'
+    spec:
+      project: "default"
+      source:
+        repoURL: https://github.com/zhweiliu/infrastructure
+        targetRevision: main
+        path: argocd/clusters/infrastructure/{{path.basename}}
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: '{{.path.basename}}'
+      syncPolicy:
+        automated: 
+          prune: true
+          allowEmpty: true
+        syncOptions:
+        - CreateNamespace=true
+        - ServerSideApply=true


### PR DESCRIPTION
## Summary
Delegating cluster infrastructure to argocd.

## Reference
https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/#the-applicationset-resource
https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Generators-Git/