### PR TITLE
feat(argocd): correct argo-workflows server to use http scheme.

### DIFF
--- a/argocd/clusters/apps/argo-workflows/kustomization.yaml
+++ b/argocd/clusters/apps/argo-workflows/kustomization.yaml
@@ -11,4 +11,4 @@ patches:
   - target:
       kind: Deployment
       name: argo-server
-    path: patch-auth-mode.yaml
+    path: patch-argo-server.yaml

--- a/argocd/clusters/apps/argo-workflows/patch-argo-server.yaml
+++ b/argocd/clusters/apps/argo-workflows/patch-argo-server.yaml
@@ -1,0 +1,7 @@
+- op: replace
+  path: /spec/template/spec/containers/0/args
+  value:
+    - server
+    - --auth-mode=server    
+- op: remove
+  path: /spec/template/spec/containers/0/readinessProbe/httpGet/scheme

--- a/argocd/clusters/apps/argo-workflows/patch-auth-mode.yaml
+++ b/argocd/clusters/apps/argo-workflows/patch-auth-mode.yaml
@@ -1,5 +1,0 @@
-- op: replace
-  path: /spec/template/spec/containers/0/args
-  value:
-    - server
-    - --auth-mode=server


### PR DESCRIPTION
## Summary
correct argo-workflows server to use http scheme.

## References

