### PR TITLE
feat(argocd): patch applicationset ignore difference of deployment divisor.

### DIFF
--- a/argocd/clusters/apps/applicationset.yaml
+++ b/argocd/clusters/apps/applicationset.yaml
@@ -29,3 +29,9 @@ spec:
         syncOptions:
         - CreateNamespace=true
         - ServerSideApply=true
+      ignoreDifferences:
+        - group: apps
+          kind: Deployment
+          jqPathExpressions:
+            - .spec.template.spec.containers[].env[].valueFrom.resourceFieldRef.divisor
+            - .spec.template.spec.initContainers[].env[].valueFrom.resourceFieldRef.divisor


### PR DESCRIPTION
## Summary
patch applicationset ignore difference of deployment divisor.

## References

